### PR TITLE
Restore lost xsd files that disappeared when we deployed the new www.jmxtrans.org website

### DIFF
--- a/schema/embedded/jmxtrans-1.0.xsd
+++ b/schema/embedded/jmxtrans-1.0.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2010-2013 the original author or authors
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining
+ ~ a copy of this software and associated documentation files (the
+ ~ "Software"), to deal in the Software without restriction, including
+ ~ without limitation the rights to use, copy, modify, merge, publish,
+ ~ distribute, sublicense, and/or sell copies of the Software, and to
+ ~ permit persons to whom the Software is furnished to do so, subject to
+ ~ the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be
+ ~ included in all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ ~ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ ~ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ ~ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ ~ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ ~ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ~
+-->
+<xsd:schema xmlns="http://www.jmxtrans.org/schema/embedded"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:tool="http://www.springframework.org/schema/tool"
+            targetNamespace="http://www.jmxtrans.org/schema/embedded"
+            elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xsd:annotation>
+        <xsd:documentation><![CDATA[
+    Defines the configuration elements for Embedded JmxTrans.
+        ]]></xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:import namespace="http://www.springframework.org/schema/beans"
+                schemaLocation="http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"/>
+
+    <xsd:element name="jmxtrans">
+        <xsd:annotation>
+            <xsd:documentation><![CDATA[
+    Load Embedded JmxTrans
+            ]]></xsd:documentation>
+            <xsd:appinfo>
+                <tool:annotation>
+                    <tool:exports
+                            type="org.jmxtrans.embedded.EmbeddedJmxTrans"/>
+                </tool:annotation>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="configuration" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation><![CDATA[
+    jmxtrans json configuration file defined as a spring resource. Can be 'classpath:...', 'file://...', 'http://...', ...
+                        ]]></xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:attribute name="id" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+    The unique identifier for a bean. A bean id may not be used more than once
+    within the same <beans> element. Optional. If not defined, defaults to 'jmxtrans'.
+                ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="configuration" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+    The location of the json configuration file, as a Spring resource location: a URL, a "classpath:" pseudo URL,
+    or a relative file path.
+    Multiple configurations may be specified, separated by commas.
+                ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+            <xsd:attribute name="ignore-configuration-not-found" type="xsd:boolean"
+                           default="false">
+                <xsd:annotation>
+                    <xsd:documentation><![CDATA[
+    Specifies if failure to find the JSON configuration resource location should be ignored.  Default
+    is "false", meaning that if there is no file in the configuration specified an exception will
+    be raised at runtime.
+                ]]></xsd:documentation>
+                </xsd:annotation>
+            </xsd:attribute>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/schema/embedded/jmxtrans.xsd
+++ b/schema/embedded/jmxtrans.xsd
@@ -1,0 +1,1 @@
+jmxtrans-1.0.xsd


### PR DESCRIPTION
Restore lost xsd files that disappeared when we deployed the new www.jmxtrans.org website.

See old content at https://github.com/jmxtrans/jmxtrans.github.com.old/tree/master/schema/embedded .
